### PR TITLE
Add example to use grafana and telegraf with sawtooth-raft

### DIFF
--- a/raft/stats/README.md
+++ b/raft/stats/README.md
@@ -1,0 +1,61 @@
+# Configure Grafana, Telegraf To The Sawtooth-Raft Network
+
+The document helps you setup the Grafana to the sawtooth-raft network.
+The setup is demonstrated using the instructions
+[here](https://sawtooth.hyperledger.org/docs/raft/nightly/master/configuring_deploying.html#starting-a-multi-node-raft-network).
+
+## Setup
+
+### Step 0: Clone the repositories
+
+Clone the [sawtooth-core](https://github.com/hyperledger/sawtooth-core),
+[sawtooth-contrib](https://github.com/hyperledger/sawtooth-contrib)
+and [sawtooth-raft](https://github.com/hyperledger/sawtooth-raft)
+repositories to your work environment.
+
+### Step 1: Bring up the admin service
+
+```shell_script
+$ cd sawtooth-raft/adhoc
+$ docker-compose -f admin.yaml up -d
+```
+
+### Step 2: Bring up the Grafana and the InfluxDB services
+
+```shell_script
+$ cd sawtooth-contrib/raft/stats
+$ SAWTOOTH_CORE=/path/to/the/repository/sawtooth-core docker-compose -f grafana.yaml up -d
+```
+
+### Step 3: Bring up the nodes as stated in sawtooth-raft documentation
+
+**Note:** *Use the file `node-with-stats.yaml` instead of `node.yaml`
+to get telegraf stats.*
+
+Here are the instructions to use the `node-with-stats.yaml` file.
+Bring up `n` number of non-genesis nodes, so that the logical volume
+which is created in the `Step 1` has the required credentials for the
+`genesis` node.
+
+a. For non-genesis node
+
+```shell_script
+$ SAWTOOTH_RAFT=/path/to/the/repository/sawtooth-raft SAWTOOTH_CORE=/path/to/the/repository/sawtooth-core docker-compose -f node-with-stats.yaml -p <NODENAME> up
+```
+
+b. For genesis node
+
+```shell_script
+$ SAWTOOTH_RAFT=/path/to/the/repository/sawtooth-raft SAWTOOTH_CORE=/path/to/repository/sawtooth-core GENESIS=1 docker-compose -f node-with-stats.yaml -p <NODENAME> up
+```
+
+**Caution:**
+Refer to the `sawtooth-raft` documentation for the explanation.
+A `genesis` block is required for all the nodes to bootstrap the network,
+notice how the nodes wait on the `genesis` block creation in
+`node-with-stats.yaml` file.
+
+### Step 4: Access Grafana
+
+Go to the [http://localhost:3000](http://localhost:3000) link in your
+favorite browser.

--- a/raft/stats/grafana.yaml
+++ b/raft/stats/grafana.yaml
@@ -1,0 +1,58 @@
+# Copyright 2020 Walmart Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "3.6"
+
+networks:
+    rest_apis:
+        external:
+            name: raft_rest_apis
+    validators:
+        external:
+            name: raft_validators
+    
+services:
+
+    influxdb:
+        build:
+            context: $SAWTOOTH_CORE/docker
+            dockerfile: influxdb/sawtooth-stats-influxdb
+        image: sawtooth-stats-influxdb:latest
+        container_name: sawtooth-stats-influxdb
+        ports:
+            - "8086:8086"
+        networks:
+            default:
+            rest_apis:
+            validators:
+        stop_signal: SIGKILL
+    
+    grafana:
+        build:
+            context: $SAWTOOTH_CORE/docker
+            dockerfile: grafana/sawtooth-stats-grafana
+        image: sawtooth-stats-grafana:latest
+        container_name: sawtooth-stats-grafana
+        ports:
+            - "3000:3000"
+        networks:
+            default:
+            rest_apis:
+            validators:
+        volumes:
+            - $SAWTOOTH_CORE:/project/sawtooth-core
+        depends_on:
+            - influxdb
+        stop_signal: SIGKILL

--- a/raft/stats/node-with-stats.yaml
+++ b/raft/stats/node-with-stats.yaml
@@ -1,0 +1,142 @@
+# Copyright 2020 Walmart Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "3.6"
+
+# Validators across all compose files join this docker network for inter-node
+# communication
+networks:
+    validators:
+        external:
+            name: raft_validators
+    rest_apis:
+        external:
+            name: raft_rest_apis
+    
+volumes:
+    raft_shared_data:
+        external: true
+
+services:
+    
+    validator:
+        build:
+            context: $SAWTOOTH_RAFT/tests
+            dockerfile: sawtooth-raft-test.dockerfile
+        labels:
+            - "com.sawtooth.isolation_id=${ISOLATION_ID:-}"
+        command: "bash -c \"\
+          cp /telegraf/telegraf.conf /etc/telegraf/telegraf.conf && \
+          (telegraf &) && \
+          if [ ! -e /etc/sawtooth/keys/validator.pub ]; then sawadm keygen; fi && \
+          if [ ! -e /shared_data/validators/$$(hostname) ]; then \
+            cat /etc/sawtooth/keys/validator.pub > /shared_data/validators/$$(hostname); \
+          fi && \
+          echo \\\"-- /var/lib/sawtooth\\\" && ls /var/lib/sawtooth && \
+          echo \\\"-- /shared_data/validators \\\" && ls /shared_data/validators && \
+          if [ ${GENESIS:-0} != 0 -a ! -e /shared_data/genesis.batch ]; then \
+            echo \\\"Running Genesis\\\" && \
+            sawset genesis \
+              -k /shared_data/keys/settings.priv \
+              -o config-genesis.batch && \
+            sawset proposal create \
+              -k /shared_data/keys/settings.priv \
+              sawtooth.consensus.algorithm.name=sawtooth-raft-engine \
+              sawtooth.consensus.algorithm.version=0.1.0 \
+              sawtooth.consensus.raft.peers=\\['\\\"'$$(cd /shared_data/validators && paste $$(ls -1) -d , | sed s/,/\\\\\\\",\\\\\\\"/g)'\\\"'\\]
+              -o config.batch && \
+            sawadm genesis \
+              config-genesis.batch config.batch && \
+            cp /var/lib/sawtooth/genesis.batch /shared_data/genesis.batch && \
+            ls /var/lib/sawtooth; \
+          fi && \
+          export PEERS=$$(for host in $$(ls /shared_data/validators -1); do \
+                if [ $$host != $$(hostname) ]; then \
+                  echo \\\"tcp://$$host:8800\\\"; \
+                fi; done | tr \\\"\n\\\" \\\",\\\" | sed s\\/,$$\\/\\\n\\/); \
+          echo \\\"-- PEERS \\\" && echo \\\"PEERS=$$PEERS\\\"; \
+          if [ \\\"$$PEERS\\\" = \\\"\\\" ]; then \
+            echo \\\"No peers to connect to...\\\";
+            sawtooth-validator -vv \
+                --endpoint tcp://$$(hostname):8800 \
+                --bind component:tcp://eth0:4004 \
+                --bind network:tcp://eth1:8800 \
+                --bind consensus:tcp://eth0:5050 \
+                --peering static \
+                --scheduler parallel \
+                --opentsdb-url http://influxdb:8086 \
+                --opentsdb-db metrics; \
+          else \
+            echo \\\"Connecting to $$PEERS\\\";
+            sawtooth-validator -vv \
+                --endpoint tcp://$$(hostname):8800 \
+                --bind component:tcp://eth0:4004 \
+                --bind network:tcp://eth1:8800 \
+                --bind consensus:tcp://eth0:5050 \
+                --peering static \
+                --peers $$PEERS \
+                --scheduler parallel \
+                --opentsdb-url http://influxdb:8086 \
+                --opentsdb-db metrics; \
+          fi \
+        \""
+        volumes:
+            - raft_shared_data:/shared_data
+            - $SAWTOOTH_CORE/docker:/telegraf
+        networks:
+            default:
+            validators:
+        expose:
+            - 8800
+        stop_signal: SIGKILL
+
+    raft:
+        image: hyperledger/sawtooth-raft-engine:nightly
+        labels:
+            - "com.sawtooth.isolation_id=${ISOLATION_ID:-}"
+        command: raft-engine --connect tcp://validator:5050 -v
+
+    rest-api:
+        image: hyperledger/sawtooth-rest-api:nightly
+        labels:
+            - "com.sawtooth.isolation_id=${ISOLATION_ID:-}"
+        command: "bash -c \"
+          if [ ! -e /shared_data/rest_apis/$$(hostname) ]; then \
+            touch /shared_data/rest_apis/$$(hostname);
+          fi && \
+          sawtooth-rest-api --connect tcp://validator:4004 --bind $$(hostname):8008 --opentsdb-url http://influxdb:8086 --opentsdb-db metrics; \
+        \""
+        volumes:
+            - raft_shared_data:/shared_data
+        networks:
+            default:
+            rest_apis:
+        expose:
+            - 8008
+        stop_signal: SIGKILL
+    
+    intkey-tp-python:
+        image: hyperledger/sawtooth-intkey-tp-python:nightly
+        labels:
+            - "com.sawtooth.isolation_id=${ISOLATION_ID:-}"
+        command: intkey-tp-python -vv -C tcp://validator:4004
+        stop_signal: SIGKILL
+    
+    settings-tp:
+        image: hyperledger/sawtooth-settings-tp:nightly
+        labels:
+            - "com.sawtooth.isolation_id=${ISOLATION_ID:-}"
+        command: settings-tp -C tcp://validator:4004 -v
+        stop_signal: SIGKILL


### PR DESCRIPTION
1. Add README file with instructions on how to run the
grafana service with telegraf stats enabled.
2. Add a compose file to start grafana and influxdb
services.
3. Add a docker compose file that enables telegraf stats
in a validator service.

This was in my fork for a long time now. Pushing it to the sawtooth-contrib repository.

Signed-off-by: S m, Aruna <aruna.mohan@walmartlabs.com>