### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,9 +8,7 @@
 | Boyd Johnson | boydjohnson |
 | Dan Middleton | dcmiddle |
 | Darian Plumb | dplumb94 |
-| James Mitchell | jsmitchell |
 | Peter Schwarz | peterschwarz |
-| Richard Berg | rberg2 |
 | Ryan Beck-Buysse | rbuysse |
 | Shawn Amundson | vaporos |
 
@@ -18,3 +16,5 @@
 | Name | GitHub |
 | --- | --- |
 | Adam Ludvik | aludvik |
+| James Mitchell | jsmitchell |
+| Richard Berg | rberg2 |


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>